### PR TITLE
move mxsamples code to plant_sounds_externals.lua

### DIFF
--- a/lib/plant_sounds.lua
+++ b/lib/plant_sounds.lua
@@ -32,9 +32,9 @@ function plant_sounds:new(parent)
   ps.engine_note_on = function(note_to_play, freq, random_note_frequency)
     envelopes[parent.id].update_envelope()
     --engine.note_on(note_to_play, freq, random_note_frequency)
-    local ins=math.random(#instruments)
-    note_to_play=note_to_play+instruments_adjust[ins]
-    skeys:on({name=instruments[ins],pan=instruments_pan[ins],midi=note_to_play,velocity=120})
+    --local ins=math.random(#instruments)
+    --note_to_play=note_to_play+instruments_adjust[ins]
+    --skeys:on({name=instruments[ins],pan=instruments_pan[ins],midi=note_to_play,velocity=120})
   end
     
   ps.play = function(node_obj)


### PR DESCRIPTION
moving mxsamples code to plant_sounds_externals.lua is the simplest way to get note frequencies working for samples.